### PR TITLE
Ensure forced and scheduled restarts escalate correctly

### DIFF
--- a/src/main/java/me/benrobson/idlerestart/IdleRestartCore.java
+++ b/src/main/java/me/benrobson/idlerestart/IdleRestartCore.java
@@ -16,6 +16,17 @@ public class IdleRestartCore {
     private long actualRestartTimeMillis = 0; // Time when server will actually restart
     private SchedulerTask currentShutdownTask;
     private SchedulerTask idleCheckTask;
+    private SchedulerTask scheduledForceTask;
+    private long scheduledForceCheckTimeMillis = 0L;
+    private boolean scheduledRestartForcePending = false;
+    private RestartType currentRestartType = RestartType.NONE;
+
+    public enum RestartType {
+        NONE,
+        IDLE,
+        SCHEDULED,
+        FORCED
+    }
 
     public IdleRestartCore(PlatformAdapter platform, DiscordWebhookManager webhookManager) {
         this.platform = platform;
@@ -36,22 +47,35 @@ public class IdleRestartCore {
         idleCheckTask = platform.runTaskTimer(() -> {
             if (platform.getOnlinePlayerCount() <= platform.getNumberOfPlayers() && !isRestarting) {
                 platform.info("Server is idle. Scheduling restart.");
-                scheduleRestart(platform.getIdleMinutes(), "due to inactivity");
+                scheduleRestart(platform.getIdleMinutes(), "due to inactivity", RestartType.IDLE);
             }
         }, 0L, 20L * 60L); // Check every minute
     }
 
     public void scheduleRestart(int minutes, String reason) {
-        if (isRestarting && actualRestartTimeMillis < System.currentTimeMillis() + (minutes * 60 * 1000L)) {
+        scheduleRestart(minutes, reason, RestartType.IDLE);
+    }
+
+    public void scheduleRestart(int minutes, String reason, RestartType type) {
+        if (minutes <= 0) {
+            platform.warning("Attempted to schedule a restart with a non-positive delay (" + minutes + "). Defaulting to 1 minute.");
+            minutes = 1;
+        }
+
+        long now = System.currentTimeMillis();
+        long requestedRestartTimeMillis = now + (minutes * 60L * 1000L);
+        if (isRestarting && actualRestartTimeMillis <= requestedRestartTimeMillis && type != RestartType.FORCED) {
             platform.info("Restart already scheduled and sooner or at the same time.");
             return;
         }
 
-        cancelCurrentShutdownTask(); // Cancel any existing shutdown task
+        cancelCurrentShutdownTask();
+        cancelScheduledForceTask();
 
         isRestarting = true;
-        restartTimeMillis = System.currentTimeMillis();
-        actualRestartTimeMillis = System.currentTimeMillis() + (minutes * 60 * 1000L);
+        restartTimeMillis = now;
+        actualRestartTimeMillis = requestedRestartTimeMillis;
+        currentRestartType = type;
 
         if (platform.isBroadcastRestart()) {
             String message = platform.getIdlePrefix() + " Server will restart in " + minutes + " minutes " + reason + ".";
@@ -64,12 +88,16 @@ public class IdleRestartCore {
             }
         }
 
+        if (type == RestartType.SCHEDULED) {
+            scheduleScheduledForceCheck();
+        }
+
         currentShutdownTask = platform.runTaskLater(() -> {
-            if (isRestarting) { // Re-check in case it was cancelled
+            if (isRestarting) {
                 platform.info("Executing scheduled server shutdown.");
                 platform.shutdown();
             }
-        }, minutes * 60 * 20L); // minutes to ticks
+        }, minutes * 60L * 20L);
         platform.info("Server restart scheduled in " + minutes + " minutes.");
         webhookManager.sendRestartNotification(reason);
         platform.callEvent(new RestartScheduledEvent(minutes, reason));
@@ -77,7 +105,7 @@ public class IdleRestartCore {
 
     public void forceRestart(int minutes) {
         platform.info("Forcing server restart in " + minutes + " minutes.");
-        scheduleRestart(minutes, "due to forced restart");
+        scheduleRestart(minutes, "due to forced restart", RestartType.FORCED);
         platform.callEvent(new RestartForcedEvent(minutes));
     }
 
@@ -88,11 +116,66 @@ public class IdleRestartCore {
         }
     }
 
+    private void cancelScheduledForceTask() {
+        if (scheduledForceTask != null && !scheduledForceTask.isCancelled()) {
+            scheduledForceTask.cancel();
+        }
+        scheduledForceTask = null;
+        scheduledForceCheckTimeMillis = 0L;
+        scheduledRestartForcePending = false;
+    }
+
+    private void scheduleScheduledForceCheck() {
+        int delayMinutes = platform.getScheduledRestartForceDelayMinutes();
+        if (delayMinutes <= 0) {
+            platform.info("Scheduled restart force delay is zero or negative; skipping force escalation.");
+            scheduledRestartForcePending = false;
+            scheduledForceCheckTimeMillis = 0L;
+            return;
+        }
+
+        scheduledRestartForcePending = true;
+        long now = System.currentTimeMillis();
+        scheduledForceCheckTimeMillis = now + (delayMinutes * 60L * 1000L);
+        platform.info("Scheduled restart will be forced if the player threshold is still met in " + delayMinutes + " minutes.");
+
+        scheduledForceTask = platform.runTaskLater(() -> handleScheduledForceCheck(delayMinutes), delayMinutes * 60L * 20L);
+    }
+
+    private void handleScheduledForceCheck(int delayMinutes) {
+        scheduledForceTask = null;
+        if (!scheduledRestartForcePending) {
+            platform.info("Scheduled restart force escalation no longer required.");
+            scheduledForceCheckTimeMillis = 0L;
+            return;
+        }
+
+        scheduledRestartForcePending = false;
+        scheduledForceCheckTimeMillis = 0L;
+
+        int onlinePlayers = platform.getOnlinePlayerCount();
+        int threshold = platform.getNumberOfPlayers();
+        if (onlinePlayers <= threshold) {
+            platform.info("Scheduled restart threshold not met after " + delayMinutes + " minutes (" + onlinePlayers + " online, threshold " + threshold + "). Initiating forced restart.");
+            forceRestart(1);
+        } else {
+            platform.info("Scheduled restart threshold met after " + delayMinutes + " minutes (" + onlinePlayers + " online, threshold " + threshold + "). Forced restart not required.");
+        }
+    }
+
     public void cancelRestart(String reason) {
         if (isRestarting) {
+            RestartType cancelledType = currentRestartType;
             isRestarting = false;
+            currentRestartType = RestartType.NONE;
+            restartTimeMillis = 0L;
             actualRestartTimeMillis = 0;
             cancelCurrentShutdownTask();
+            if (cancelledType != RestartType.SCHEDULED) {
+                cancelScheduledForceTask();
+            } else if (scheduledRestartForcePending) {
+                platform.info("Scheduled restart cancelled, but force check remains pending.");
+            }
             platform.info("Server restart cancelled. Reason: " + reason);
             if (platform.isBroadcastRestart()) {
                 platform.broadcastMessage(platform.getIdlePrefix() + " Server restart has been cancelled. Reason: " + reason);
@@ -103,12 +186,11 @@ public class IdleRestartCore {
 
     public void onPlayerJoin() {
         if (isRestarting) {
-            long remainingTimeMillis = actualRestartTimeMillis - System.currentTimeMillis();
-            int joinDelayMillis = platform.getJoinDelayMinutes() * 60 * 1000;
+            if (currentRestartType == RestartType.FORCED) {
+                platform.info("Player joined while a forced restart is pending. Restart will continue as scheduled.");
+                return;
+            }
 
-            // Only delay if the player joins before the final moments OR if joinDelay is significant enough
-            // This avoids issues where a player joins 1 second before restart and it gets delayed.
-            // For now, let's always delay if a restart is pending.
             cancelRestart("player joined");
             platform.info("Player joined. Restart cancelled. Scheduling new idle check after " + platform.getJoinDelayMinutes() + " minutes.");
 
@@ -118,6 +200,8 @@ public class IdleRestartCore {
             // And the PlayerJoinListener says "Schedule a new restart check after the delay"
             // This seems more aligned with "delaying" the restart process.
             platform.runTaskLater(this::startIdleCheck, platform.getJoinDelayMinutes() * 60 * 20L);
+        } else if (scheduledRestartForcePending) {
+            platform.info("Player joined while a scheduled restart force check is pending. Restart remains cancelled unless the idle threshold is met when the force check runs.");
         }
     }
 
@@ -131,6 +215,18 @@ public class IdleRestartCore {
 
     public long getActualRestartTimeMillis() {
         return actualRestartTimeMillis;
+    }
+
+    public RestartType getCurrentRestartType() {
+        return currentRestartType;
+    }
+
+    public boolean isScheduledRestartForcePending() {
+        return scheduledRestartForcePending;
+    }
+
+    public long getScheduledForceCheckTimeMillis() {
+        return scheduledRestartForcePending ? scheduledForceCheckTimeMillis : 0L;
     }
 
     public void setIdleMinutes(int minutes) {
@@ -158,6 +254,7 @@ public class IdleRestartCore {
             idleCheckTask.cancel();
         }
         cancelCurrentShutdownTask();
+        cancelScheduledForceTask();
     }
 
     public void reload() {

--- a/src/main/java/me/benrobson/idlerestart/IdleRestartCore.java
+++ b/src/main/java/me/benrobson/idlerestart/IdleRestartCore.java
@@ -1,8 +1,5 @@
 package me.benrobson.idlerestart;
 
-import me.benrobson.idlerestart.api.events.RestartCancelledEvent;
-import me.benrobson.idlerestart.api.events.RestartForcedEvent;
-import me.benrobson.idlerestart.api.events.RestartScheduledEvent;
 import me.benrobson.idlerestart.platform.PlatformAdapter;
 import me.benrobson.idlerestart.platform.PlayerAdapter;
 import me.benrobson.idlerestart.platform.SchedulerTask;
@@ -100,13 +97,13 @@ public class IdleRestartCore {
         }, minutes * 60L * 20L);
         platform.info("Server restart scheduled in " + minutes + " minutes.");
         webhookManager.sendRestartNotification(reason);
-        platform.callEvent(new RestartScheduledEvent(minutes, reason));
+        platform.fireRestartScheduledEvent(minutes, reason);
     }
 
     public void forceRestart(int minutes) {
         platform.info("Forcing server restart in " + minutes + " minutes.");
         scheduleRestart(minutes, "due to forced restart", RestartType.FORCED);
-        platform.callEvent(new RestartForcedEvent(minutes));
+        platform.fireRestartForcedEvent(minutes);
     }
 
     private void cancelCurrentShutdownTask() {
@@ -180,7 +177,7 @@ public class IdleRestartCore {
             if (platform.isBroadcastRestart()) {
                 platform.broadcastMessage(platform.getIdlePrefix() + " Server restart has been cancelled. Reason: " + reason);
             }
-            platform.callEvent(new RestartCancelledEvent(reason));
+            platform.fireRestartCancelledEvent(reason);
         }
     }
 

--- a/src/main/java/me/benrobson/idlerestart/api/IdleRestartAPI.java
+++ b/src/main/java/me/benrobson/idlerestart/api/IdleRestartAPI.java
@@ -1,6 +1,7 @@
 package me.benrobson.idlerestart.api;
 
 import me.benrobson.idlerestart.IdleRestartCore;
+import me.benrobson.idlerestart.IdleRestartCore.RestartType;
 
 public class IdleRestartAPI {
     private final IdleRestartCore core;
@@ -17,6 +18,17 @@ public class IdleRestartAPI {
      */
     public void scheduleRestart(int minutes, String reason) {
         core.scheduleRestart(minutes, reason);
+    }
+
+    /**
+     * Schedules a server restart with the specified restart type.
+     *
+     * @param minutes The number of minutes until the restart.
+     * @param reason  The reason for the restart.
+     * @param type    The type of restart to schedule.
+     */
+    public void scheduleRestart(int minutes, String reason, RestartType type) {
+        core.scheduleRestart(minutes, reason, type);
     }
 
     /**
@@ -62,5 +74,32 @@ public class IdleRestartAPI {
      */
     public long getActualRestartTimeMillis() {
         return core.getActualRestartTimeMillis();
+    }
+
+    /**
+     * Gets the type of restart currently scheduled.
+     *
+     * @return The current restart type.
+     */
+    public RestartType getCurrentRestartType() {
+        return core.getCurrentRestartType();
+    }
+
+    /**
+     * Checks if a scheduled restart force escalation is pending.
+     *
+     * @return true if a scheduled restart force check is pending, false otherwise.
+     */
+    public boolean isScheduledRestartForcePending() {
+        return core.isScheduledRestartForcePending();
+    }
+
+    /**
+     * Gets the time when a scheduled restart force check will occur.
+     *
+     * @return The time in milliseconds since the epoch, or 0 if no force check is pending.
+     */
+    public long getScheduledForceCheckTimeMillis() {
+        return core.getScheduledForceCheckTimeMillis();
     }
 }

--- a/src/main/java/me/benrobson/idlerestart/commands/IdleRestartStatusCommand.java
+++ b/src/main/java/me/benrobson/idlerestart/commands/IdleRestartStatusCommand.java
@@ -2,6 +2,7 @@ package me.benrobson.idlerestart.commands;
 
 import me.benrobson.idlerestart.IdleRestartCore;
 import me.benrobson.idlerestart.platform.PlatformAdapter;
+import me.benrobson.idlerestart.IdleRestartCore.RestartType;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -36,17 +37,36 @@ public class IdleRestartStatusCommand implements CommandExecutor {
             long remainingMinutes = TimeUnit.MILLISECONDS.toMinutes(remainingTimeMillis);
             long remainingSeconds = TimeUnit.MILLISECONDS.toSeconds(remainingTimeMillis) % 60;
 
+            RestartType restartType = core.getCurrentRestartType();
 
             sender.sendMessage(platform.getIdlePrefix() + " Server restart is currently pending.");
             sender.sendMessage(platform.getIdlePrefix() + " -> Initiated " + pendingSinceMinutes + " minutes ago.");
+            sender.sendMessage(platform.getIdlePrefix() + " -> Restart type: " + formatRestartType(restartType) + ".");
             if (remainingTimeMillis > 0) {
                 sender.sendMessage(platform.getIdlePrefix() + " -> Time until restart: " + remainingMinutes + "m " + remainingSeconds + "s.");
             } else {
                 sender.sendMessage(platform.getIdlePrefix() + " -> Restart is imminent or slightly overdue.");
             }
+            if (restartType == RestartType.FORCED) {
+                sender.sendMessage(platform.getIdlePrefix() + " -> This restart is forced and will not be cancelled by player joins.");
+            }
         } else {
             sender.sendMessage(platform.getIdlePrefix() + " No server restart is currently pending.");
+            if (core.isScheduledRestartForcePending()) {
+                long forceTimeMillis = core.getScheduledForceCheckTimeMillis();
+                long currentTimeMillis = System.currentTimeMillis();
+                long remainingForceMillis = Math.max(forceTimeMillis - currentTimeMillis, 0);
+                long remainingForceMinutes = TimeUnit.MILLISECONDS.toMinutes(remainingForceMillis);
+                long remainingForceSeconds = TimeUnit.MILLISECONDS.toSeconds(remainingForceMillis) % 60;
+                sender.sendMessage(platform.getIdlePrefix() + " A scheduled restart force check is pending.");
+                sender.sendMessage(platform.getIdlePrefix() + " -> Time until escalation: " + remainingForceMinutes + "m " + remainingForceSeconds + "s.");
+            }
         }
         return true;
+    }
+
+    private String formatRestartType(RestartType type) {
+        String formatted = type.name().toLowerCase().replace('_', ' ');
+        return formatted.substring(0, 1).toUpperCase() + formatted.substring(1);
     }
 }

--- a/src/main/java/me/benrobson/idlerestart/platform/BukkitPlatformAdapter.java
+++ b/src/main/java/me/benrobson/idlerestart/platform/BukkitPlatformAdapter.java
@@ -150,6 +150,11 @@ public class BukkitPlatformAdapter implements PlatformAdapter {
     }
 
     @Override
+    public int getScheduledRestartForceDelayMinutes() {
+        return plugin.getConfig().getInt("scheduled-restarts.force-delay-minutes", 15);
+    }
+
+    @Override
     public void reload() {
         plugin.reload();
     }

--- a/src/main/java/me/benrobson/idlerestart/platform/BukkitPlatformAdapter.java
+++ b/src/main/java/me/benrobson/idlerestart/platform/BukkitPlatformAdapter.java
@@ -1,6 +1,9 @@
 package me.benrobson.idlerestart.platform;
 
 import me.benrobson.idlerestart.IdleRestartMain;
+import me.benrobson.idlerestart.api.events.RestartCancelledEvent;
+import me.benrobson.idlerestart.api.events.RestartForcedEvent;
+import me.benrobson.idlerestart.api.events.RestartScheduledEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Sound;
@@ -175,9 +178,17 @@ public class BukkitPlatformAdapter implements PlatformAdapter {
     }
 
     @Override
-    public void callEvent(Object event) {
-        if (event instanceof org.bukkit.event.Event) {
-            Bukkit.getPluginManager().callEvent((org.bukkit.event.Event) event);
-        }
+    public void fireRestartScheduledEvent(int minutes, String reason) {
+        Bukkit.getPluginManager().callEvent(new RestartScheduledEvent(minutes, reason));
+    }
+
+    @Override
+    public void fireRestartForcedEvent(int minutes) {
+        Bukkit.getPluginManager().callEvent(new RestartForcedEvent(minutes));
+    }
+
+    @Override
+    public void fireRestartCancelledEvent(String reason) {
+        Bukkit.getPluginManager().callEvent(new RestartCancelledEvent(reason));
     }
 }

--- a/src/main/java/me/benrobson/idlerestart/platform/PlatformAdapter.java
+++ b/src/main/java/me/benrobson/idlerestart/platform/PlatformAdapter.java
@@ -39,6 +39,10 @@ public interface PlatformAdapter {
     String getDiscordWebhookUrl();
     String getDiscordServerName();
 
-    // Events
-    void callEvent(Object event);
+    // Events (platform-specific implementations may no-op if unsupported)
+    void fireRestartScheduledEvent(int minutes, String reason);
+
+    void fireRestartForcedEvent(int minutes);
+
+    void fireRestartCancelledEvent(String reason);
 }

--- a/src/main/java/me/benrobson/idlerestart/platform/PlatformAdapter.java
+++ b/src/main/java/me/benrobson/idlerestart/platform/PlatformAdapter.java
@@ -31,6 +31,7 @@ public interface PlatformAdapter {
     boolean isScheduledRestartEnabled();
     java.util.List<String> getScheduledRestartTimes();
     String getScheduledRestartTimezone();
+    int getScheduledRestartForceDelayMinutes();
     void reload();
 
     // Discord Webhook

--- a/src/main/java/me/benrobson/idlerestart/platform/VelocityPlatformAdapter.java
+++ b/src/main/java/me/benrobson/idlerestart/platform/VelocityPlatformAdapter.java
@@ -208,8 +208,17 @@ public class VelocityPlatformAdapter implements PlatformAdapter {
     }
 
     @Override
-    public void callEvent(Object event) {
-        // Velocity does not have a synchronous, Bukkit-like event bus that can be called this way.
-        // This will be a no-op for Velocity.
+    public void fireRestartScheduledEvent(int minutes, String reason) {
+        // Velocity does not expose Bukkit-style events; this is a no-op.
+    }
+
+    @Override
+    public void fireRestartForcedEvent(int minutes) {
+        // Velocity does not expose Bukkit-style events; this is a no-op.
+    }
+
+    @Override
+    public void fireRestartCancelledEvent(String reason) {
+        // Velocity does not expose Bukkit-style events; this is a no-op.
     }
 }

--- a/src/main/java/me/benrobson/idlerestart/platform/VelocityPlatformAdapter.java
+++ b/src/main/java/me/benrobson/idlerestart/platform/VelocityPlatformAdapter.java
@@ -183,6 +183,11 @@ public class VelocityPlatformAdapter implements PlatformAdapter {
     }
 
     @Override
+    public int getScheduledRestartForceDelayMinutes() {
+        return plugin.getConfigManager().getScheduledRestartForceDelayMinutes();
+    }
+
+    @Override
     public void reload() {
         plugin.reload();
     }

--- a/src/main/java/me/benrobson/idlerestart/scheduler/ScheduledRestartManager.java
+++ b/src/main/java/me/benrobson/idlerestart/scheduler/ScheduledRestartManager.java
@@ -1,6 +1,7 @@
 package me.benrobson.idlerestart.scheduler;
 
 import me.benrobson.idlerestart.IdleRestartCore;
+import me.benrobson.idlerestart.IdleRestartCore.RestartType;
 import me.benrobson.idlerestart.platform.PlatformAdapter;
 
 import java.time.ZoneId;
@@ -11,7 +12,9 @@ import me.benrobson.idlerestart.platform.SchedulerTask;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
 
 public class ScheduledRestartManager {
     private final IdleRestartCore core;
@@ -32,13 +35,8 @@ public class ScheduledRestartManager {
 
         List<String> restartTimes = platform.getScheduledRestartTimes();
         String timezone = platform.getScheduledRestartTimezone();
-        ZoneId zoneId;
-        try {
-            zoneId = ZoneId.of(timezone);
-        } catch (Exception e) {
-            platform.severe("Invalid timezone specified in the configuration: " + timezone + ". Defaulting to UTC.");
-            zoneId = ZoneId.of("UTC");
-        }
+        ZoneId zoneId = resolveZoneId(timezone);
+        platform.info("Using timezone " + zoneId.getId() + " for scheduled restarts.");
 
         ZonedDateTime now = ZonedDateTime.now(zoneId);
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
@@ -52,16 +50,62 @@ public class ScheduledRestartManager {
                 }
 
                 long delay = ChronoUnit.MILLIS.between(now, restartTime);
+                long delayTicks = Math.max(1L, delay / 50L);
                 SchedulerTask task = platform.runTaskLater(() -> {
                     platform.info("Executing scheduled restart.");
-                    core.scheduleRestart(1, "as scheduled"); // Restart in 1 minute
-                }, delay / 50); // Convert to ticks
+                    core.scheduleRestart(1, "as scheduled", RestartType.SCHEDULED); // Restart in 1 minute
+                }, delayTicks); // Convert to ticks
                 scheduledTasks.add(task);
-                platform.info("Scheduled restart for " + time + " " + timezone);
+                platform.info("Scheduled restart for " + time + " " + zoneId.getId());
             } catch (Exception e) {
                 platform.severe("Invalid time format for scheduled restart: " + time + " - " + e.getMessage());
             }
         }
+    }
+
+    private ZoneId resolveZoneId(String timezone) {
+        if (timezone == null) {
+            platform.warning("No timezone specified for scheduled restarts. Defaulting to system default: " + ZoneId.systemDefault().getId());
+            return ZoneId.systemDefault();
+        }
+
+        String trimmed = timezone.trim();
+        if (trimmed.isEmpty()) {
+            platform.warning("Empty timezone specified for scheduled restarts. Defaulting to system default: " + ZoneId.systemDefault().getId());
+            return ZoneId.systemDefault();
+        }
+
+        Set<String> candidates = new LinkedHashSet<>();
+        candidates.add(trimmed);
+        candidates.add(trimmed.replace(' ', '_'));
+        candidates.add(trimmed.replace(' ', '/'));
+        candidates.add(trimmed.replace('_', '/'));
+
+        String lower = trimmed.toLowerCase(Locale.ROOT);
+        candidates.add(lower);
+        candidates.add(lower.replace(' ', '_'));
+        candidates.add(lower.replace(' ', '/'));
+
+        if (!trimmed.contains("/")) {
+            candidates.add("Australia/" + trimmed.replace(' ', '_'));
+            candidates.add("Australia/" + lower.replace(' ', '_'));
+        }
+
+        String upper = trimmed.toUpperCase(Locale.ROOT);
+        String alias = ZoneId.SHORT_IDS.get(upper);
+        if (alias != null) {
+            candidates.add(alias);
+        }
+
+        for (String candidate : candidates) {
+            try {
+                return ZoneId.of(candidate);
+            } catch (Exception ignored) {
+            }
+        }
+
+        platform.severe("Invalid timezone specified in the configuration: " + timezone + ". Defaulting to UTC.");
+        return ZoneId.of("UTC");
     }
 
     public void cancelTasks() {

--- a/src/main/java/me/benrobson/idlerestart/velocity/VelocityConfigManager.java
+++ b/src/main/java/me/benrobson/idlerestart/velocity/VelocityConfigManager.java
@@ -28,6 +28,7 @@ public class VelocityConfigManager {
     private boolean scheduledRestartEnabled = false;
     private List<String> scheduledRestartTimes = Arrays.asList("04:00", "16:00");
     private String scheduledRestartTimezone = "UTC";
+    private int scheduledRestartForceDelayMinutes = 15;
 
     // Discord Webhook
     private boolean discordWebhookEnabled = false;
@@ -66,6 +67,7 @@ public class VelocityConfigManager {
             scheduledRestartEnabled = config.getOrElse("scheduled-restarts.enabled", scheduledRestartEnabled);
             scheduledRestartTimes = config.getOrElse("scheduled-restarts.times", scheduledRestartTimes);
             scheduledRestartTimezone = config.getOrElse("scheduled-restarts.timezone", scheduledRestartTimezone);
+            scheduledRestartForceDelayMinutes = config.getIntOrElse("scheduled-restarts.force-delay-minutes", scheduledRestartForceDelayMinutes);
 
             // Discord Webhook
             discordWebhookEnabled = config.getOrElse("discord.enabled", discordWebhookEnabled);
@@ -105,8 +107,10 @@ public class VelocityConfigManager {
         if (!config.contains("scheduled-restarts.enabled")) config.set("scheduled-restarts.enabled", scheduledRestartEnabled);
         config.setComment("scheduled-restarts.times", "A list of times in HH:mm format (24-hour clock) to restart the server");
         if (!config.contains("scheduled-restarts.times")) config.set("scheduled-restarts.times", scheduledRestartTimes);
-        config.setComment("scheduled-restarts.timezone", "The timezone for scheduled restarts. Full list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones");
+        config.setComment("scheduled-restarts.timezone", "The timezone for scheduled restarts (examples: UTC, Australia/Sydney). Full list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones");
         if (!config.contains("scheduled-restarts.timezone")) config.set("scheduled-restarts.timezone", scheduledRestartTimezone);
+        config.setComment("scheduled-restarts.force-delay-minutes", "Minutes to wait before forcing a scheduled restart if the idle threshold is still met");
+        if (!config.contains("scheduled-restarts.force-delay-minutes")) config.set("scheduled-restarts.force-delay-minutes", scheduledRestartForceDelayMinutes);
 
         // Discord Webhook
         config.setComment("discord.enabled", "Enable or disable Discord webhook notifications");
@@ -133,6 +137,7 @@ public class VelocityConfigManager {
     public boolean isScheduledRestartEnabled() { return scheduledRestartEnabled; }
     public java.util.List<String> getScheduledRestartTimes() { return scheduledRestartTimes; }
     public String getScheduledRestartTimezone() { return scheduledRestartTimezone; }
+    public int getScheduledRestartForceDelayMinutes() { return scheduledRestartForceDelayMinutes; }
     public boolean isDiscordWebhookEnabled() { return discordWebhookEnabled; }
     public String getDiscordWebhookUrl() { return discordWebhookUrl; }
     public String getDiscordServerName() { return discordServerName; }

--- a/src/main/java/me/benrobson/idlerestart/velocity/command/VelocityIdleRestartStatusCommand.java
+++ b/src/main/java/me/benrobson/idlerestart/velocity/command/VelocityIdleRestartStatusCommand.java
@@ -4,8 +4,7 @@ import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.command.SimpleCommand;
 import me.benrobson.idlerestart.IdleRestartCore;
 import me.benrobson.idlerestart.platform.PlatformAdapter;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
+import me.benrobson.idlerestart.IdleRestartCore.RestartType;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 
 import java.util.List;
@@ -26,10 +25,11 @@ public class VelocityIdleRestartStatusCommand implements SimpleCommand {
         CommandSource source = invocation.source();
 
         if (!source.hasPermission("idlerestart.status")) { // Using the same permission node
-            source.sendMessage(LegacyComponentSerializer.legacyAmpersand().deserialize(platform.getIdlePrefix() + " &cYou do not have permission to use this command."));
+            sendMessage(source, platform.getIdlePrefix() + " &cYou do not have permission to use this command.");
             return;
         }
 
+        String prefix = platform.getIdlePrefix();
         if (core.isRestartPending()) {
             long initiatedTimeMillis = core.getRestartInitiatedTimeMillis();
             long actualRestartTimeMillis = core.getActualRestartTimeMillis();
@@ -42,15 +42,30 @@ public class VelocityIdleRestartStatusCommand implements SimpleCommand {
             long remainingMinutes = TimeUnit.MILLISECONDS.toMinutes(remainingTimeMillis);
             long remainingSeconds = TimeUnit.MILLISECONDS.toSeconds(remainingTimeMillis) % 60;
 
-            source.sendMessage(LegacyComponentSerializer.legacyAmpersand().deserialize(platform.getIdlePrefix() + " &eProxy restart is currently pending."));
-            source.sendMessage(LegacyComponentSerializer.legacyAmpersand().deserialize(platform.getIdlePrefix() + " &e -> Initiated " + pendingSinceMinutes + " minutes ago."));
+            RestartType restartType = core.getCurrentRestartType();
+
+            sendMessage(source, prefix + " &eProxy restart is currently pending.");
+            sendMessage(source, prefix + " &e -> Initiated " + pendingSinceMinutes + " minutes ago.");
+            sendMessage(source, prefix + " &e -> Restart type: " + formatRestartType(restartType) + ".");
             if (remainingTimeMillis > 0) {
-                source.sendMessage(LegacyComponentSerializer.legacyAmpersand().deserialize(platform.getIdlePrefix() + " &e -> Time until restart: " + remainingMinutes + "m " + remainingSeconds + "s."));
+                sendMessage(source, prefix + " &e -> Time until restart: " + remainingMinutes + "m " + remainingSeconds + "s.");
             } else {
-                source.sendMessage(LegacyComponentSerializer.legacyAmpersand().deserialize(platform.getIdlePrefix() + " &e -> Restart is imminent or slightly overdue."));
+                sendMessage(source, prefix + " &e -> Restart is imminent or slightly overdue.");
+            }
+            if (restartType == RestartType.FORCED) {
+                sendMessage(source, prefix + " &c -> This restart is forced and will not be cancelled by player joins.");
             }
         } else {
-            source.sendMessage(LegacyComponentSerializer.legacyAmpersand().deserialize(platform.getIdlePrefix() + " &aNo proxy restart is currently pending."));
+            sendMessage(source, prefix + " &aNo proxy restart is currently pending.");
+            if (core.isScheduledRestartForcePending()) {
+                long forceTimeMillis = core.getScheduledForceCheckTimeMillis();
+                long currentTimeMillis = System.currentTimeMillis();
+                long remainingForceMillis = Math.max(forceTimeMillis - currentTimeMillis, 0);
+                long remainingForceMinutes = TimeUnit.MILLISECONDS.toMinutes(remainingForceMillis);
+                long remainingForceSeconds = TimeUnit.MILLISECONDS.toSeconds(remainingForceMillis) % 60;
+                sendMessage(source, prefix + " &eA scheduled restart force check is pending.");
+                sendMessage(source, prefix + " &e -> Time until escalation: " + remainingForceMinutes + "m " + remainingForceSeconds + "s.");
+            }
         }
     }
 
@@ -62,5 +77,14 @@ public class VelocityIdleRestartStatusCommand implements SimpleCommand {
     @Override
     public boolean hasPermission(Invocation invocation) {
         return invocation.source().hasPermission("idlerestart.status");
+    }
+
+    private void sendMessage(CommandSource source, String message) {
+        source.sendMessage(LegacyComponentSerializer.legacyAmpersand().deserialize(message));
+    }
+
+    private String formatRestartType(RestartType type) {
+        String formatted = type.name().toLowerCase().replace('_', ' ');
+        return formatted.substring(0, 1).toUpperCase() + formatted.substring(1);
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -25,9 +25,11 @@ scheduled-restarts:
   times:
     - "04:00"
     - "16:00"
-  # The timezone to use for scheduled restarts.
+  # The timezone to use for scheduled restarts (examples: UTC, Australia/Sydney).
   # A list of valid timezones can be found here: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
   timezone: "UTC"
+  # Minutes to wait before forcing a scheduled restart if the idle player threshold is still met
+  force-delay-minutes: 15
 
 # Discord Webhook
 # Enable or disable Discord webhook notifications


### PR DESCRIPTION
## Summary
- prevent forced restarts from being cancelled by player joins and expose restart type/state details
- add a configurable delay that escalates scheduled restarts to forced restarts when the idle threshold persists
- improve scheduled restart timezone handling and configuration messaging to support Australia/Sydney explicitly

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download maven-resources-plugin from Maven Central due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_b_68dd8e4ffdd883309ed3e44c7ac2c2b0