### PR TITLE
Use Spigot restart instead of shutdown for idle restarts

### DIFF
--- a/src/main/java/me/benrobson/idlerestart/IdleRestartCore.java
+++ b/src/main/java/me/benrobson/idlerestart/IdleRestartCore.java
@@ -91,7 +91,7 @@ public class IdleRestartCore {
 
         currentShutdownTask = platform.runTaskLater(() -> {
             if (isRestarting) {
-                platform.info("Executing scheduled server shutdown.");
+                platform.info("Executing scheduled server restart.");
                 platform.shutdown();
             }
         }, minutes * 60L * 20L);

--- a/src/main/java/me/benrobson/idlerestart/platform/BukkitPlatformAdapter.java
+++ b/src/main/java/me/benrobson/idlerestart/platform/BukkitPlatformAdapter.java
@@ -79,7 +79,13 @@ public class BukkitPlatformAdapter implements PlatformAdapter {
 
     @Override
     public void shutdown() {
-        Bukkit.shutdown();
+        info("Attempting to restart the server via Spigot API.");
+        try {
+            Bukkit.spigot().restart();
+        } catch (UnsupportedOperationException | NoSuchMethodError ex) {
+            warning("Spigot restart is not supported on this platform. Falling back to shutdown.");
+            Bukkit.shutdown();
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
- switch the Bukkit adapter to request a restart via the Spigot API and fall back to shutdown when unavailable
- adjust restart logging to reflect restart behavior

## Testing
- mvn test *(fails: unable to download maven-resources-plugin from Maven Central, HTTP 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69381d4ead848320b8f4d28dce1243b9)